### PR TITLE
Add Stryker to NodeBB code base 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,6 @@ theme/*.sublime-workspace
 theme/.idea
 theme/.vscode
 theme/node_modules/
+
+# stryker temp files
+.stryker-tmp

--- a/require-main.js
+++ b/require-main.js
@@ -3,8 +3,8 @@
 // this forces `require.main.require` to always be relative to this directory
 // this allows plugins to use `require.main.require` to reference NodeBB modules
 // without worrying about multiple parent modules
-if (require.main !== module) {
-    require.main.require = function (path) {
-        return require(path);
-    };
-}
+// if (require.main !== module) {
+//     require.main.require = function (path) {
+//         return require(path);
+//     };
+// }

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -66,6 +66,7 @@ const yargs = require('yargs');
 const pkg = require('../../install/package.json');
 const file = require('../file');
 const prestart = require('../prestart');
+const { exit } = require('process');
 
 program.configureHelp(require('./colors'));
 
@@ -98,7 +99,7 @@ prestart.versionCheck();
 
 if (!configExists && process.argv[2] !== 'setup') {
     require('./setup').webInstall();
-    return;
+    exit;
 }
 
 process.env.CONFIG = configFile;

--- a/src/install.js
+++ b/src/install.js
@@ -492,11 +492,11 @@ async function enableDefaultPlugins() {
 
     let defaultEnabled = [
         'nodebb-plugin-composer-default',
-        'nodebb-plugin-markdown',
+        // 'nodebb-plugin-markdown',
         'nodebb-plugin-mentions',
         'nodebb-widget-essentials',
-        'nodebb-rewards-essentials',
-        'nodebb-plugin-emoji',
+        // 'nodebb-rewards-essentials',
+        // 'nodebb-plugin-emoji',
         'nodebb-plugin-emoji-android',
         'nodebb-plugin-dbsearch',
     ];

--- a/stryker.conf.json
+++ b/stryker.conf.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "./node_modules/@stryker-mutator/core/schema/stryker-schema.json",
+  "_comment": "This config was generated using 'stryker init'. Please take a look at: https://stryker-mutator.io/docs/stryker-js/configuration/ for more information.",
+  "packageManager": "npm",
+  "reporters": [
+    "html",
+    "clear-text",
+    "progress"
+  ],
+  "testRunner": "command",
+  "testRunner_comment": "Take a look at (missing 'homepage' URL in package.json) for information about the command plugin.",
+  "coverageAnalysis": "off",
+  "buildCommand": "./nodebb build"
+}


### PR DESCRIPTION
Stryker is a framework to conduct automatic mutation testing. I have setup Stryker and did minor changes to the code base for Stryker to run. 

Below is terminal output by Stryker as a proof of successful execution: 
stryker run
00:50:47 (67751) INFO ProjectReader Found 529 of 10465 file(s) to be mutated.
`isModuleDeclaration` has been deprecated, please migrate to `isImportOrExportDeclaration`
    at Object.isModuleDeclaration (/Users/shoutianze/Desktop/S23/17313/spring23-nodebb-team-c2/node_modules/@babel/types/lib/validators/generated/index.js:3940:35)
    at isValidParent (file:///Users/shoutianze/Desktop/S23/17313/spring23-nodebb-team-c2/node_modules/@stryker-mutator/instrumenter/dist/src/mutators/string-literal-mutator.js:19:15)
00:50:50 (67751) INFO Instrumenter Instrumented 529 source file(s) with 49978 mutant(s)
00:50:51 (67751) INFO ConcurrencyTokenProvider Creating 7 test runner process(es).
00:50:52 (67751) INFO Sandbox Running build command "./nodebb build" in "/Users/shoutianze/Desktop/S23/17313/spring23-nodebb-team-c2/.stryker-tmp/sandbox205211".
00:51:05 (67751) WARN Sandbox Could not symlink "node_modules" in sandbox directory, it is already created in the sandbox. Please remove the node_modules from your sandbox files. Alternatively, set `symlinkNodeModules` to `false` to disable this warning.
00:51:05 (67751) INFO DryRunExecutor Starting initial test run (command test runner with "off" coverage analysis). This may take a while.
00:54:32 (67751) INFO DryRunExecutor Initial test run succeeded. Ran 1 tests in 3 minutes 26 seconds (net 206295 ms, overhead 1 ms).
Mutation testing  [                              ] 0% (elapsed: ~1m, remaining: ~40h 23m) 34/49978 Mutants tested (0 survived, 0 timed out)